### PR TITLE
feat(evals): Make waza evals actually validate model output

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  copilot: read
+  models: read
 
 jobs:
   eval:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  copilot: read
 
 jobs:
   eval:
@@ -16,16 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Azure Developer CLI
-        uses: Azure/setup-azd@v2
-      - name: Install waza extension
-        run: |
-          azd config set alpha.extensions on
-          azd ext source add -n waza -t url -l https://raw.githubusercontent.com/microsoft/waza/main/registry.json
-          azd ext install microsoft.azd.waza
+      - name: Install waza
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - name: Run evaluations
-        continue-on-error: true
-        run: azd waza run --output-dir ./results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: waza run --output-dir ./results -v
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.waza.yaml
+++ b/.waza.yaml
@@ -9,7 +9,7 @@ files:
   taskGlob: tasks/*.yaml
   taskFileSuffix: .yaml
 defaults:
-  engine: mock
+  engine: copilot-sdk
   model: claude-sonnet-4.6
   timeout: 300
   parallel: false

--- a/evals/cosmosdb-best-practices/eval.yaml
+++ b/evals/cosmosdb-best-practices/eval.yaml
@@ -9,7 +9,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
-  executor: mock
+  executor: copilot-sdk
   model: claude-sonnet-4.6
 metrics:
   - name: task_completion
@@ -22,5 +22,7 @@ graders:
     config:
       max_tool_calls: 10
       max_duration_ms: 60000
+  - type: text
+    name: content_validation
 tasks:
   - "tasks/*.yaml"

--- a/evals/cosmosdb-best-practices/tasks/basic-usage.yaml
+++ b/evals/cosmosdb-best-practices/tasks/basic-usage.yaml
@@ -12,3 +12,6 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "customerId"
+    - "partition key"

--- a/evals/cosmosdb-best-practices/tasks/edge-case.yaml
+++ b/evals/cosmosdb-best-practices/tasks/edge-case.yaml
@@ -11,3 +11,6 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "cross-partition"
+    - "tenantId"

--- a/evals/cosmosdb-best-practices/tasks/indexing-composite.yaml
+++ b/evals/cosmosdb-best-practices/tasks/indexing-composite.yaml
@@ -15,3 +15,5 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "composite"

--- a/evals/cosmosdb-best-practices/tasks/model-embed-decision.yaml
+++ b/evals/cosmosdb-best-practices/tasks/model-embed-decision.yaml
@@ -15,3 +15,5 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "embed"

--- a/evals/cosmosdb-best-practices/tasks/query-point-read.yaml
+++ b/evals/cosmosdb-best-practices/tasks/query-point-read.yaml
@@ -16,3 +16,5 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "point read"

--- a/evals/cosmosdb-best-practices/tasks/sdk-singleton.yaml
+++ b/evals/cosmosdb-best-practices/tasks/sdk-singleton.yaml
@@ -24,3 +24,8 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "singleton"
+  output_not_contains:
+    - "looks good"
+    - "no issues"

--- a/evals/cosmosdb-best-practices/tasks/should-not-trigger.yaml
+++ b/evals/cosmosdb-best-practices/tasks/should-not-trigger.yaml
@@ -11,3 +11,7 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_not_contains:
+    - "partition key"
+    - "CosmosClient"
+    - "Request Unit"

--- a/evals/cosmosdb-best-practices/tasks/throughput-autoscale.yaml
+++ b/evals/cosmosdb-best-practices/tasks/throughput-autoscale.yaml
@@ -15,3 +15,5 @@ inputs:
 expected:
   outcomes:
     - type: task_completed
+  output_contains:
+    - "autoscale"


### PR DESCRIPTION
Test PR to verify CI works with real model execution.

Changes:
- Switch executor from mock to copilot-sdk (Claude Sonnet 4.6)
- Add text content assertions to all 8 tasks
- Replace azd extension with standalone waza binary (fixes protocol mismatch)
- Remove continue-on-error so failures are visible
- Fix .waza.yaml defaults from mock to copilot-sdk

Verified locally: 8/8 pass, ~2 min, 11 premium requests.